### PR TITLE
JUNEAU-158 The KEYS link should have KEYS as the text|FIX

### DIFF
--- a/content/downloads.html
+++ b/content/downloads.html
@@ -109,10 +109,10 @@
 	
 	<h5 class='toc'>Verifying file integrity</h5>
 	<p>
-		Instructions on verifying the integrity of the downloaded files can be found <a class='doclink' href='https://www.apache.org/info/verification.html'>here</a>.
+		How to <a class='doclink' href='https://www.apache.org/info/verification.html'>verify downloaded files</a>.
 	</p>
 	<p>
-		The KEYS file can be found <a class='doclink' href='https://www.apache.org/dist/juneau/KEYS'>here</a>.
+		<a class='doclink' href='https://www.apache.org/dist/juneau/KEYS'>Download KEYS </a>file.
 	</p>
 	<h5 class='toc'>Older releases</h5>
 	<p class='download'>


### PR DESCRIPTION
Changed two link texts for 1. Verification of downloaded files 2. KEYS file
![Capture](https://user-images.githubusercontent.com/20625637/66183860-e6e92500-e697-11e9-867f-02bdf28de2ef.JPG)
